### PR TITLE
Fix broken RSpec 3 specs

### DIFF
--- a/spec/cloudwatchtographite_spec.rb
+++ b/spec/cloudwatchtographite_spec.rb
@@ -1,13 +1,13 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe CloudwatchToGraphite::Base do
   before :each do
-    @base = CloudwatchToGraphite::Base.new 'foo', 'bar', 'us-east-1'
+    @base = CloudwatchToGraphite::Base.new "foo", "bar", "us-east-1"
   end
 
   describe ".new" do
     it "takes three parameters and returns a CloudwatchToGraphite::Base" do
-      @base.should be_an_instance_of CloudwatchToGraphite::Base
+      expect(@base).to be_an_instance_of CloudwatchToGraphite::Base
     end
   end
 
@@ -18,11 +18,10 @@ describe CloudwatchToGraphite::Base do
     it "allows setting a prefix for carbon" do
       expect { @base.carbon_prefix = 123 }.to \
         raise_error(CloudwatchToGraphite::ArgumentTypeError)
-      expect { @base.carbon_prefix = '' }.to \
+      expect { @base.carbon_prefix = "" }.to \
         raise_error(CloudwatchToGraphite::ArgumentLengthError)
       @base.carbon_prefix = "the_prefix"
-      @base.carbon_prefix.should eql "the_prefix"
+      expect(@base.carbon_prefix).to eql "the_prefix"
     end
   end
 end
-

--- a/spec/factories/metricdefinition.rb
+++ b/spec/factories/metricdefinition.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
-  factory :metricdefinition, class: CloudwatchToGraphite::MetricDefinition do
+  factory :metricdefinition, :class => CloudwatchToGraphite::MetricDefinition do
     sequence(:MetricName) { |n| "metricname#{n}" }
     sequence(:Namespace) { |n| "namespace#{n}" }
     Period 90
-    Unit 'None'
-    after(:build) do |definition, evaluator|
-      definition.add_statistic('Sum')
-      definition.add_statistic('Average')
+    Unit "None"
+    after(:build) do |definition, _evaluator|
+      definition.add_statistic("Sum")
+      definition.add_statistic("Average")
     end
   end
 end

--- a/spec/factories/metricdimension.rb
+++ b/spec/factories/metricdimension.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :metricdimension, class: CloudwatchToGraphite::MetricDimension do
+  factory :metricdimension, :class => CloudwatchToGraphite::MetricDimension do
     sequence(:Name) { |n| "name#{n}" }
     sequence(:Value) { |n| "value#{n}" }
   end

--- a/spec/loadmetrics_spec.rb
+++ b/spec/loadmetrics_spec.rb
@@ -1,27 +1,12 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe CloudwatchToGraphite::LoadMetrics do
-
   describe "#load_content" do
     it "it should not load invalid metrics" do
-      content = {'shmetrics' => 'foo'}
+      content = { "shmetrics" => "foo" }
       expect {
-        CloudwatchToGraphite::LoadMetrics::load_content(content)
+        CloudwatchToGraphite::LoadMetrics.load_content(content)
       }.to raise_error(CloudwatchToGraphite::ArgumentTypeError)
     end
-
-    #it "it should load valid metrics" do
-    #  content = {
-    #    'metrics'    => [ {
-    #      'namespace'  => 'thenamespace',
-    #      'metricname' => 'themetricname',
-    #      'statistics' => 'Average',
-    #      'period'     => 1,
-    #      'dimensions' => [ { 'name' => 'thename', 'value' => 'thevalue' }]
-    #    }]
-    #  }
-    #  metrics = CloudwatchToGraphite::LoadMetrics::load_content(content)
-    #  metrics.should be_an(Array)
-    #end
   end
 end

--- a/spec/metricdefinition_spec.rb
+++ b/spec/metricdefinition_spec.rb
@@ -1,27 +1,27 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe CloudwatchToGraphite::MetricDefinition do
   before :each do
     @definition = FactoryGirl.build(
       :metricdefinition,
-      MetricName: 'foometricname',
-      Namespace:  'foonamespace',
-      Unit:       'Bits'
+      :MetricName => "foometricname",
+      :Namespace  => "foonamespace",
+      :Unit       => "Bits"
     )
 
-    @valid_string = 'a' * 255
-    @invalid_string = 'z' * 256
+    @valid_string = "a" * 255
+    @invalid_string = "z" * 256
   end
 
   describe ".create_and_fill" do
     it "should be a MetricDefinition" do
-      @definition.should be_an_instance_of \
+      expect(@definition).to be_an_instance_of \
         CloudwatchToGraphite::MetricDefinition
     end
     it "should require valid arguments" do
       expect {
         CloudwatchToGraphite::MetricDefinition.create_and_fill(
-          {'namespace' => 'blah'}
+          "namespace" => "blah"
         )
       }.to raise_error(CloudwatchToGraphite::ParseError)
     end
@@ -30,13 +30,13 @@ describe CloudwatchToGraphite::MetricDefinition do
   describe ".new" do
     it "takes no parameters and returns a MetricDefinition" do
       d = CloudwatchToGraphite::MetricDefinition.new
-      d.should be_an_instance_of CloudwatchToGraphite::MetricDefinition
+      expect(d).to be_an_instance_of CloudwatchToGraphite::MetricDefinition
     end
   end
 
   describe ".Namespace" do
     it "returns the correct namespace" do
-      @definition.Namespace.should eql 'foonamespace'
+      expect(@definition.Namespace).to eql "foonamespace"
     end
   end
 
@@ -49,13 +49,13 @@ describe CloudwatchToGraphite::MetricDefinition do
         @definition.Namespace = @invalid_string
       }.to raise_error(CloudwatchToGraphite::ArgumentLengthError)
       @definition.Namespace = @valid_string
-      @definition.Namespace.should eql @valid_string
+      expect(@definition.Namespace).to eql @valid_string
     end
   end
 
   describe ".MetricName" do
     it "returns the correct metricname" do
-      @definition.MetricName.should eql 'foometricname'
+      expect(@definition.MetricName).to eql "foometricname"
     end
   end
 
@@ -68,24 +68,24 @@ describe CloudwatchToGraphite::MetricDefinition do
         @definition.MetricName = @invalid_string
       }.to raise_error(CloudwatchToGraphite::ArgumentLengthError)
       @definition.MetricName = @valid_string
-      @definition.MetricName.should eql @valid_string
+      expect(@definition.MetricName).to eql @valid_string
     end
   end
 
   describe ".Statistics" do
     it "returns the correct statistics" do
       statistics = @definition.Statistics
-      statistics.should be_an Array
-      statistics.should include 'Sum'
-      statistics.should include 'Average'
-      statistics.should have(2).items
+      expect(statistics).to be_an Array
+      expect(statistics).to include "Sum"
+      expect(statistics).to include "Average"
+      expect(statistics.count).to eq(2)
     end
   end
 
   describe ".add_statistic" do
     it "only accepts valid arguments" do
       expect {
-        @definition.add_statistic('NotValid')
+        @definition.add_statistic("NotValid")
       }.to raise_error(CloudwatchToGraphite::ArgumentTypeError)
     end
   end
@@ -97,24 +97,24 @@ describe CloudwatchToGraphite::MetricDefinition do
         @definition.add_dimension(d)
       end
       expect {
-          @definition.add_dimension(FactoryGirl.build(:metricdimension))
+        @definition.add_dimension(FactoryGirl.build(:metricdimension))
       }.to raise_error(CloudwatchToGraphite::TooManyDimensionError)
     end
   end
 
   describe ".Period" do
     it "returns the correct period" do
-      @definition.Period.should eql 90
+      expect(@definition.Period).to eql 90
     end
   end
 
   describe ".Period=" do
     it "only accepts valid arguments" do
       expect {
-        @definition.Period = 'abc'
+        @definition.Period = "abc"
       }.to raise_error(CloudwatchToGraphite::ArgumentTypeError)
       @definition.Period = 1
-      @definition.Period.should eql 1
+      expect(@definition.Period).to eql 1
     end
   end
 
@@ -125,19 +125,19 @@ describe CloudwatchToGraphite::MetricDefinition do
         @definition.add_dimension(d)
       end
       dimensions = @definition.Dimensions
-      dimensions.should be_an Array
-      dimensions.should have(2).items
+      expect(dimensions).to be_an Array
+      expect(dimensions.count).to eq(2)
       dimensions.each do |d|
-        d.should be_a Hash
-        d.should have_key('Name')
-        d.should have_key('Value')
+        expect(d).to be_a Hash
+        expect(d).to have_key("Name")
+        expect(d).to have_key("Value")
       end
     end
   end
 
   describe ".Unit" do
     it "returns the correct unit" do
-      @definition.Unit.should eql 'Bits'
+      expect(@definition.Unit).to eql "Bits"
     end
   end
 end

--- a/spec/metricdimension_spec.rb
+++ b/spec/metricdimension_spec.rb
@@ -1,19 +1,19 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe CloudwatchToGraphite::MetricDimension do
   before :each do
     @dimension = FactoryGirl.build(
       :metricdimension,
-      Name: 'testname',
-      Value: 'testval'
+      :Name  => "testname",
+      :Value => "testval"
     )
-    @valid_string = 'a' * 255
-    @invalid_string = 'z' * 256
+    @valid_string = "a" * 255
+    @invalid_string = "z" * 256
   end
 
   describe ".new" do
     it "takes two parameters and returns a MetricDimension" do
-      @dimension.should be_an_instance_of \
+      expect(@dimension).to be_an_instance_of \
         CloudwatchToGraphite::MetricDimension
     end
   end
@@ -21,14 +21,14 @@ describe CloudwatchToGraphite::MetricDimension do
   describe ".create_from_hash" do
     it "should return a MetricDimension" do
       d = CloudwatchToGraphite::MetricDimension.create_from_hash(
-        {'name' => 'a', 'value' => 'b'}
+        "name" => "a", "value" => "b"
       )
-      d.should be_an_instance_of CloudwatchToGraphite::MetricDimension
+      expect(d).to be_an_instance_of CloudwatchToGraphite::MetricDimension
     end
     it "should require valid arguments" do
       expect {
         CloudwatchToGraphite::MetricDimension.create_from_hash(
-          {'name' => 'blah'}
+          "name" => "blah"
         )
       }.to raise_error(CloudwatchToGraphite::ArgumentTypeError)
     end
@@ -36,7 +36,7 @@ describe CloudwatchToGraphite::MetricDimension do
 
   describe ".Name" do
     it "returns the correct name" do
-      @dimension.Name.should eql 'testname'
+      expect(@dimension.Name).to eql "testname"
     end
   end
 
@@ -49,13 +49,13 @@ describe CloudwatchToGraphite::MetricDimension do
         @dimension.Name = @invalid_string
       }.to raise_error(CloudwatchToGraphite::ArgumentLengthError)
       @dimension.Name = @valid_string
-      @dimension.Name.should eql @valid_string
+      expect(@dimension.Name).to eql @valid_string
     end
   end
 
   describe ".Name" do
     it "returns the correct value" do
-      @dimension.Value.should eql 'testval'
+      expect(@dimension.Value).to eql "testval"
     end
   end
 
@@ -68,7 +68,7 @@ describe CloudwatchToGraphite::MetricDimension do
         @dimension.Value = @invalid_string
       }.to raise_error(CloudwatchToGraphite::ArgumentLengthError)
       @dimension.Value = @valid_string
-      @dimension.Value.should eql @valid_string
+      expect(@dimension.Value).to eql @valid_string
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,14 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-require 'coveralls'
-require 'rspec'
-require 'factory_girl'
+require "rspec"
+require "factory_girl"
 RSpec.configure do |config|
-    config.include FactoryGirl::Syntax::Methods
+  config.include FactoryGirl::Syntax::Methods
 end
-# must come before app requires
-Coveralls.wear!
 
-require 'cloudwatchtographite'
+require "cloudwatchtographite"
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 FactoryGirl.find_definitions

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,7 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require File.expand_path(File.dirname(__FILE__) + "/spec_helper")
 
 describe "CloudwatchToGraphite::VERSION" do
   it "STRING must be defined" do
-    CloudwatchToGraphite::VERSION::STRING.should_not be_empty
+    expect(CloudwatchToGraphite::VERSION::STRING).to_not be_empty
   end
 end


### PR DESCRIPTION
Updates to expect syntax for RSpec 3 and updates tests that were using deprecated matchers