### PR TITLE
Use Instance ID

### DIFF
--- a/lib/cloudwatchtographite/metricdefinition.rb
+++ b/lib/cloudwatchtographite/metricdefinition.rb
@@ -155,7 +155,7 @@ module CloudwatchToGraphite
        self.Namespace,
        self.MetricName,
        stat,
-       @Dimensions.join('.')
+       @Dimensions[0].Value
      ]
      path.gsub('/', '.').downcase
     end


### PR DESCRIPTION
For my usage, having the instance ID was much more valuable.  Each returned metric currently offers a unique ID, offering the Instance ID means we can track new deployments and use annotations in Grafana.

I don't think this needs a new test.